### PR TITLE
docs: padroniza readmes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,28 @@
 ## 📚 Documentação do projeto
-
-Bem-vindo a pasta de documentação da **Sprint Master**.
-
+<p style="text-align: justify;">
 Este diretório reúne toda a documentação técnica, funcional e arquitetura do sistema, facilitando o desenvolvimento e manutenção do projeto para a equipe.
 
-## 📌 Objetivo
+</p>
 
-A documentação do projeto Sprint Master tem como foco auxiliar a equipe na organização e gerenciamento das sprints utilizando práticas em Scrum e metodologias ágeis. 
+### Objetivo
+---
 
+<p style="text-align: justify;">
+A documentação do projeto Sprint Master tem como foco auxiliar a equipe na organização e gerenciamento das sprints utilizando práticas em Scrum e metodologias ágeis.
+</p>
 A documentação aqui presente serve para:
 
-- Registrar arquitetura do sistema
+- Registrar e explicar a arquitetura do sistema
 - Centralizar informações técnicas do projeto
-- Explicar a arquitetura do sistema
 - Descrever funcionalidades
 - Registrar decisões técnicas
-- Registrar as funcionalidades
 - Documentar o acompanhamento do desenvolvimento
-- Registrar modelagem, backlog, diagramas, estruturas e identidade visual do projeto
+- Documentar modelagem do banco de Dados e identidade visual do projeto
 
+<br>
 
-## 🧱 Estrutura da Documentação
-
+### Estrutura da Documentação
+---
 ```bash
 docs/
 │
@@ -38,3 +39,12 @@ docs/
 ├── requisitos/ # Requisitos funcionais, não funcionais e restrições do projeto.
 │
 └── dod.md/ # Definition of Done.
+```
+
+<br>
+
+---
+
+<div align="center">
+    <i> Desenvolvido por TechFellas <br>2026</i>
+</div>

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,16 +1,17 @@
-# 🎨 Design do Projeto
+## 🎨 Design do Projeto
 
-## 📌 Visão Geral 
 Pasta com design projetados no figma que serviram de base para a criação das telas do projeto.
-*   **Data:** 04/2026
-*   **Status:** Finalizado
-*   **Designers:** [`TechFellas Team`](https://github.com/TechFellasAbp)
-*   **Link do Figma:** [`Figma`](https://www.figma.com/design/BBtXebf9w59mgf3cQGnnoz/Sprint-Master?node-id=0-1&t=cIcdONMlzXqXtFye-1) 
+- **Link para o Figma:** [`Figma`](https://www.figma.com/design/BBtXebf9w59mgf3cQGnnoz/Sprint-Master?node-id=0-1&t=cIcdONMlzXqXtFye-1) 
 
-## 🎨 Guia de Estilo
+<br>
+
+### Guia de Estilo
+---
 - **Paleta de Cores:** `#DEEDFF`, `#113B70`, `#09264A`, `#0072FF`, `#F9B420`, `#FFF8EF`
 - **Fonte das páginas:** [`Roboto`](https://fonts.google.com/?preview.script=Latn&query=roboto)
 - **Fontes do certificado:** [`Crimson Text`](https://fonts.google.com/specimen/Crimson+Text?preview.script=Latn), [`Meie Script`](https://fonts.google.com/specimen/Meie+Script?preview.script=Latn)
+
+<br>
 
 ---
 

--- a/docs/diagramas/README.md
+++ b/docs/diagramas/README.md
@@ -1,33 +1,36 @@
-# 🗺️ Diagramas - Sprint Master
+## 🗃️ Diagramas do Projeto
 
- Esta pasta contém toda a documentação visual, arquitetural e de fluxo do projeto **Sprint Master**. Os diagramas aqui armazenados servem como guia para que possamos compreender a estrutura do sistema, o comportamento do usuário e a integração entre os componentes.
+<p style="text-align: justify;">
+ Esta pasta contém toda a documentação visual, arquitetural e de fluxo do projeto <b>Sprint Master</b>. Os diagramas aqui armazenados servem como guia para que possamos compreender a estrutura do sistema, o comportamento do usuário e a integração entre os componentes.
 
+Este repositório armazena e organiza a documentação visual e os diagramas arquiteturais do sistema, utilizando a especificação UML (Unified Modeling Language) para mapear os requisitos funcionais e a estrutura orientada a objetos da aplicação.
+Os diagramas estão presentes para visualização de imagens em formato SVG, ou no próprio arquivo Astah, para poder visualizar todos os diagramas em conjunto, com suas descrições personalizadas.
+</p>
 
-## 📊  Diagramas UML
+<br>
 
- Este repositório armazena e organiza a documentação visual e os diagramas arquiteturais do sistema, utilizando a especificação UML (Unified Modeling Language) para mapear os requisitos funcionais e a estrutura orientada a objetos da aplicação.
- Os diagramas estão presentes para visualização de imagens em formato SVG, ou no próprio arquivo Astah, para possibilitar a visualização de todos os diagramas em conjunto, com suas descrições personalizadas.
-
-
-
-## 📂 Estrutura de Pastas do Projeto
+### Estrutura de Pastas do Projeto
+---
 
 Abaixo está representada a estrutura de diretórios que organizam a documentação do sistema:
 
-```text
-diagramas/
-├── caso-uso/
-├── classes/
-│
-└── README.md
+```
+├ diagramas/
+│ ├ caso-uso/
+│ ├ classes/
+│ ├ sequencia/
+│ └ README.md
 ```
 
-## 📂  Diretório de Casos de Uso (caso-uso)
+<br>
 
-
+### Diretório de Casos de Uso (caso-uso)
+---
+<p style="text-align: justify;">
 No contexto da engenharia de software e da modelagem de sistemas UML, a pasta de casos de uso funciona como uma ferramenta essencial de organização e comunicação.
 
 A sua principal finalidade na interpretação de um projeto é estruturar a complexidade do sistema para facilitar a compreensão de stakeholders.
+</p>
 
 Principais finalidades e benefícios de utilizar essa estrutura:
 
@@ -35,14 +38,42 @@ Principais finalidades e benefícios de utilizar essa estrutura:
 2. Facilitação da comunicação com stakeholders
 3. Gerenciamento e atribuição de trabalho aos desenvolvedores
 
+<br>
 
-## 📂 Diretório de Classes (classes)
+### Diretório de Classes (classes)
+---
 
+<p style="text-align: justify;">
 Enquanto a pasta de casos de uso organiza o sistema sob a perspectiva das funcionalidades e regras de negócio, a pasta de classes tem como função organizar a arquitetura técnica e estrutural do código, agrupando os elementos que compõem a lógica interna e os dados do sistema.
+</p>
 
 Abaixo estão as principais finalidades e benefícios de sua utilização na interpretação de um projeto:
 
 1. Separação de camadas na arquitetura do software
 2. Gerenciamento de dependências e acoplamento de diferentes funcionalidades
 3. Controle de visibilidade e escopo de sistemas
-4. Auxílio na estruturação de código
+4. Auxilia estruturação de código
+
+<br>
+
+### Diretório de Sequência (sequencia)
+---
+
+<p style="text-align: justify;">
+A pasta de sequência tem como função documentar o fluxo de interações entre os componentes do sistema, representando a ordem das mensagens trocadas entre os objetos durante a execução de um caso de uso.
+</p>
+
+Abaixo estão as principais finalidades e benefícios de sua utilização na interpretação de um projeto:
+
+1. Visualização do fluxo de comunicação entre objetos
+2. Identificação de dependências e sequência de chamadas entre componentes
+3. Compreensão do comportamento dinâmico do sistema
+4. Auxilia na validação de lógica de negócio e fluxo de processos
+
+<br>
+
+---
+
+<div align="center">
+    <i> Desenvolvido por TechFellas <br>2026</i>
+</div>


### PR DESCRIPTION
Padronizei os readmes da pasta de `design`, `diagramas `e `documentos`. 
Segue alterações feitas:
- Adição de _"feito por techfellas"_ no final das páginas.
- Alteração de H1 para H2
- Remoção de títulos e palavras repetidas
- Correção de títulos 
- Remoção de emojis desnecessários
- Adição de divisórias entre títulos e textos.